### PR TITLE
Add parameters as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-You can provide the ``files`` argument to point to files to format.
-To search recursively for ``*.v`` and ``*.sv`` files, you can use the ``globstar`` option.
+You can specify the files to format by setting the ``files`` argument to a whitespace-separated list of file patterns.
+The patterns are [unix-like globs](https://en.wikipedia.org/wiki/Glob_(programming)#Unix-like) with support for ** (bash's "globstar").
+To recursively search for ``*.v`` and ``*.sv`` files in the `my_design` folder, you can set `files` to ``'my_design/**/*.{v,sv}'``
 
-By default ``files`` has the value ``'./**/*.{v,sv}'``.
+By default ``files`` has the value ``'./**/*.{v,sv}'``. This searches for all ``*.v`` and ``*.sv`` files in the repository.
 
 ```yaml
 - uses: chipsalliance/verible-formatter-action@main
@@ -43,7 +44,7 @@ By default ``files`` has the value ``'./**/*.{v,sv}'``.
     github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-Additionally, you can add various flags to the formatter with the ``parameter`` input:
+Additionally, you can add various flags to the formatter with the ``parameters`` input:
 
 ```yaml
 - uses: chipsalliance/verible-formatter-action@main

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The GitHub Token input is used to provide
 access to the PR.
 
 Here's a basic example to format all ``*.v`` and ``*.sv`` files:
+
 ```yaml
 name: Verible formatter example
 on:
@@ -27,16 +28,32 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-You can provide ``paths`` argument to point files to format.
-Directories will be searched recursively for ``*.v`` and ``*.sv`` files.
-``paths`` defaults to ``'.'``.
+You can provide the ``files`` argument to point to files to format.
+To search recursively for ``*.v`` and ``*.sv`` files, you can use the ``globstar`` option.
+
+By default ``files`` has the value ``'./**/*.{v,sv}'``.
 
 ```yaml
 - uses: chipsalliance/verible-formatter-action@main
   with:
-    paths: |
-      ./rtl
-      ./shared
+    files:
+      ./rtl/my_file.sv
+      ./rtl/module/*.sv
+      ./testbench/**/*.{v,sv}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Additionally, you can add various flags to the formatter with the ``parameter`` input:
+
+```yaml
+- uses: chipsalliance/verible-formatter-action@main
+  with:
+    files:
+      ./design/**/*.{v,sv}
+    parameters:
+      --indentation_spaces 4
+      --module_net_variable_alignment=preserve
+      --case_items_alignment=preserve
     github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'verible-formatter'
 description: 'This action formats Verilog/SystemVerilog code'
 author: 'Antmicro'
 inputs:
+  parameters:
+    description: 'Additional parameters to set flags for formatting'
+    required: false
+    default: ''
   paths:
     description: 'Optional array of paths to directories with source code to format'
     required: false
@@ -49,7 +53,7 @@ runs:
             export OVERRIDE_GITHUB_EVENT_PATH=`pwd`/event.json
         fi
 
-        verible-verilog-format --inplace ${{ inputs.paths }} > /dev/null 2>&1
+        verible-verilog-format --inplace ${{ inputs.parameters }} ${{ inputs.paths }} > /dev/null 2>&1
         rm -rf verible
         tmp_file=$(mktemp)
         git diff >"${tmp_file}"

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   paths:
     description: 'Optional array of paths to directories with source code to format'
     required: false
-    default: '.'
+    default: './**/*.{v,sv}'
   github_token:
     description: 'GITHUB_TOKEN'
     default: ''
@@ -53,6 +53,7 @@ runs:
             export OVERRIDE_GITHUB_EVENT_PATH=`pwd`/event.json
         fi
 
+        shopt -s globstar nullglob
         verible-verilog-format --inplace ${{ inputs.parameters }} ${{ inputs.paths }} > /dev/null 2>&1
         rm -rf verible
         tmp_file=$(mktemp)

--- a/action.yml
+++ b/action.yml
@@ -6,8 +6,8 @@ inputs:
     description: 'Additional parameters to set flags for formatting'
     required: false
     default: ''
-  paths:
-    description: 'Optional array of paths to directories with source code to format'
+  files:
+    description: 'Optional array of files with source code to format'
     required: false
     default: './**/*.{v,sv}'
   github_token:
@@ -54,7 +54,7 @@ runs:
         fi
 
         shopt -s globstar nullglob
-        verible-verilog-format --inplace ${{ inputs.parameters }} ${{ inputs.paths }} > /dev/null 2>&1
+        verible-verilog-format --inplace ${{ inputs.parameters }} ${{ inputs.files }} > /dev/null 2>&1
         rm -rf verible
         tmp_file=$(mktemp)
         git diff >"${tmp_file}"

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'This action formats Verilog/SystemVerilog code'
 author: 'Antmicro'
 inputs:
   parameters:
-    description: 'Additional parameters to set flags for formatting'
+    description: 'Additional parameters passed to formatter executable'
     required: false
     default: ''
   files:


### PR DESCRIPTION
This PR adds another input that is used to pass flags to the formatter.

~~For now, this is still WIP, as some things need to be discussed beforehand:~~

- It seems that verible's parameter handling has changed. Directories no longer specify all .v and .sv files inside them. Instead, the files have to be passed directly or wildcards can be used e.g.: design/\*/\*/\*.sv but this is only for one hierarchy and not the whole folder.

    > verible-verilog-lint .
    E20220517 09:44:17.093976 17717 verilog_linter.cc:108] Can't read '.': .: is a directory, not a file

Should the README be updated to reflect that? Or should the GitHub action mimic the old behaviour by searching for all .v and .sv files in a directory? Or maybe an issue should be opened on veribles side to allow passing directories again?

- Passing newlines to the inputs fails the action

Currently I specify my parameters like this:

    parameters:
      --indentation_spaces 4
      --module_net_variable_alignment=preserve
      --case_items_alignment=preserve

This works without problems because no newlines are added.

When I use a "|" after "parameters:" newlines will be added after every argument. The GitHub action will see this then as different commands. See [this](https://stackoverflow.com/questions/59954185/github-action-split-long-command-into-multiple-lines/66809682#66809682) stackoverflow answer for more information.

Currently the README also specifies a "|" for the paths. Maybe GitHub changed some behaviour here. Should the README be updated to reflect this?


