### PR TITLE
Optional input parameter to fail on non-compliant code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
         -diff="$diff_cmd" \
         -fail-on-error="false" <"${tmp_file}" || true
 
-        if [ ${{ inputs.check_all_codebase }} == "True" ]; then
+        if [ "${{ inputs.check_all_codebase }}" == "true" ]; then
           if [ -s "${tmp_file}" ]; then
             echo "Found code non-compliant with formatting rules!"
             exit 1

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN'
     default: ''
+  check_all_codebase:
+    description: 'If there are any formatting issues in the codebase, the action will return with an error'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -68,6 +72,15 @@ runs:
         -level="info" \
         -diff="$diff_cmd" \
         -fail-on-error="false" <"${tmp_file}" || true
+
+        if [ ${{ inputs.check_all_codebase }} ]; then
+          if [ -s "${tmp_file}"]; then
+            echo "Found code non-compliant with formatting rules!"
+            exit 1
+          else
+            echo "Codebase is compliant with formatting rules"
+          fi
+        fi
 
         echo "done running reviewdog"
         cat "${tmp_file}" | wc

--- a/action.yml
+++ b/action.yml
@@ -73,13 +73,15 @@ runs:
         -diff="$diff_cmd" \
         -fail-on-error="false" <"${tmp_file}" || true
 
-        if [ ${{ inputs.check_all_codebase }} ]; then
-          if [ -s "${tmp_file}"]; then
+        if [ ${{ inputs.check_all_codebase }} == "True" ]; then
+          if [ -s "${tmp_file}" ]; then
             echo "Found code non-compliant with formatting rules!"
             exit 1
           else
             echo "Codebase is compliant with formatting rules"
           fi
+        else
+          echo "Not reporting checks for files, which are not in current PR."
         fi
 
         echo "done running reviewdog"

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   github_token:
     description: 'GITHUB_TOKEN'
     default: ''
-  check_all_codebase:
+  fail_on_formatting_suggestions:
     description: 'If there are any formatting issues in the codebase, the action will return with an error'
     required: false
     default: 'false'
@@ -73,7 +73,7 @@ runs:
         -diff="$diff_cmd" \
         -fail-on-error="false" <"${tmp_file}" || true
 
-        if [ "${{ inputs.check_all_codebase }}" == "true" ]; then
+        if [ "${{ inputs.fail_on_formatting_suggestions }}" == "true" ]; then
           if [ -s "${tmp_file}" ]; then
             echo "Found code non-compliant with formatting rules!"
             exit 1


### PR DESCRIPTION
This PR adds an optional input parameter `check_all_codebase`, which should be either set to `true` or `false`. The parameter is used to check if file, which contains all changes reported by the formatter, is empty. If the file is empty, then that means that all scanned files are compliant with the formatting, otherwise it contains formatting suggestions. 

This allows users to create a simple pass/fail workflow to test all files against the formatting rules.