### PR TITLE
Update actions/upload-artifact from v3 to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,7 @@ runs:
         echo "# --- "
     - name: Upload artifacts
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vvf_logs
         retention-days: 7


### PR DESCRIPTION
Hi there 👋 

Verible formatter actions are failing because the version of `actions/upload-artifact` used in step `Upload artifacts` was deprecated and is now removed

https://github.com/chipsalliance/verible-formatter-action/blob/4a7c04ea202b2146752ff8d5fc26fb1db39db0e5/action.yml#L131

See: [Deprecation notice: v3 of the artifact actions - GitHub Changelog](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)