### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -128,7 +128,7 @@ runs:
         echo "# --- "
     - name: Upload artifacts
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: vvf_logs
         retention-days: 7


### PR DESCRIPTION
V3 is losing support soon, an update to V4 will prevent workflows using this action from failing